### PR TITLE
Refine card layout and swipe experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
         </div>
       </div>
       <div class="gesture-hints">
-        <div class="hint hint-left" id="hint-left">Свайп влево</div>
-        <div class="hint hint-right" id="hint-right">Свайп вправо</div>
+        <div class="hint hint-left" id="hint-left" aria-label="Свайп влево"></div>
+        <div class="hint hint-right" id="hint-right" aria-label="Свайп вправо"></div>
       </div>
     </main>
     <footer class="bottom-bar">

--- a/main.js
+++ b/main.js
@@ -109,11 +109,13 @@ function applyDrag(deltaX) {
   const progress = clamp(clamped / (width * 0.45), -1, 1);
 
   card.style.transition = 'none';
-  const rotationZ = progress * 10;
-  const rotationY = progress * 14;
-  const translateY = progress * -20;
-  const scale = 1 - Math.min(Math.abs(progress) * 0.05, 0.08);
-  card.style.transform = `translate3d(${clamped}px, ${translateY}px, 0) rotate(${rotationZ}deg) rotateY(${rotationY}deg) scale(${scale})`;
+  const rotationZ = progress * 14;
+  const rotationY = progress * 20;
+  const rotationX = -progress * 6;
+  const translateY = progress * -26;
+  const translateZ = Math.abs(progress) * -30;
+  const scale = 1 - Math.min(Math.abs(progress) * 0.04, 0.07);
+  card.style.transform = `translate3d(${clamped}px, ${translateY}px, ${translateZ}px) rotateX(${rotationX}deg) rotateY(${rotationY}deg) rotate(${rotationZ}deg) scale(${scale})`;
   card.style.opacity = `${1 - Math.min(Math.abs(progress) * 0.32, 0.32)}`;
 
   updateHintActivity(progress);
@@ -139,6 +141,22 @@ function clearHintActive() {
   elements.hintRight.classList.remove('hint--active');
 }
 
+function setHintContent(element, directionLabel, actionLabel = '') {
+  const trimmedAction = actionLabel?.trim?.() ?? '';
+  const labelText = trimmedAction ? `${directionLabel}: ${trimmedAction}` : directionLabel;
+  if (trimmedAction) {
+    element.dataset.label = trimmedAction;
+  } else {
+    delete element.dataset.label;
+  }
+  element.setAttribute('aria-label', labelText);
+  if (trimmedAction) {
+    element.title = labelText;
+  } else {
+    element.removeAttribute('title');
+  }
+}
+
 function updateHintActivity(progress) {
   if (progress <= -0.2) {
     elements.hintLeft.classList.add('hint--active');
@@ -153,16 +171,16 @@ function updateHintActivity(progress) {
 
 function updateHintLabels(card) {
   if (!card) {
-    elements.hintLeft.textContent = 'Свайп влево';
-    elements.hintRight.textContent = 'Свайп вправо';
+    setHintContent(elements.hintLeft, 'Свайп влево');
+    setHintContent(elements.hintRight, 'Свайп вправо');
     return;
   }
 
-  const leftLabel = card.choices?.left?.label ?? 'Влево';
-  const rightLabel = card.choices?.right?.label ?? 'Вправо';
+  const leftLabel = card.choices?.left?.label ?? '';
+  const rightLabel = card.choices?.right?.label ?? '';
 
-  elements.hintLeft.textContent = `Влево: ${leftLabel}`;
-  elements.hintRight.textContent = `Вправо: ${rightLabel}`;
+  setHintContent(elements.hintLeft, 'Влево', leftLabel);
+  setHintContent(elements.hintRight, 'Вправо', rightLabel);
 }
 
 async function init() {
@@ -284,8 +302,8 @@ function drawNextCard() {
   elements.image.hidden = true;
   elements.image.removeAttribute('src');
   elements.image.alt = '';
-  elements.hintLeft.textContent = 'Пауза';
-  elements.hintRight.textContent = 'Новая смена';
+  setHintContent(elements.hintLeft, 'Свайп влево', 'Пауза');
+  setHintContent(elements.hintRight, 'Свайп вправо', 'Новая смена');
   elements.status.textContent = 'Подходящих карточек нет — обновите смену.';
   disableChoices(true);
   saveState();
@@ -423,9 +441,11 @@ function playSwipeAnimation(direction) {
     const cardElement = elements.card;
     const width = window.innerWidth || cardElement.offsetWidth || 1;
     const offsetX = direction === 'left' ? -width * 1.25 : width * 1.25;
-    const rotateZ = direction === 'left' ? -22 : 22;
-    const rotateY = direction === 'left' ? -28 : 28;
-    const offsetY = -56;
+    const rotateZ = direction === 'left' ? -32 : 32;
+    const rotateY = direction === 'left' ? -48 : 48;
+    const rotateX = direction === 'left' ? 14 : -14;
+    const offsetY = -70;
+    const offsetZ = -120;
 
     const cleanup = () => {
       cardElement.style.transition = '';
@@ -444,8 +464,8 @@ function playSwipeAnimation(direction) {
     cardElement.addEventListener('transitionend', onTransitionEnd);
 
     requestAnimationFrame(() => {
-      cardElement.style.transition = 'transform 0.5s cubic-bezier(0.16, 0.84, 0.44, 1), opacity 0.5s ease';
-      cardElement.style.transform = `translate3d(${offsetX}px, ${offsetY}px, 0) rotate(${rotateZ}deg) rotateY(${rotateY}deg) scale(0.9)`;
+      cardElement.style.transition = 'transform 0.55s cubic-bezier(0.22, 0.71, 0.35, 1), opacity 0.5s ease';
+      cardElement.style.transform = `translate3d(${offsetX}px, ${offsetY}px, ${offsetZ}px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) rotate(${rotateZ}deg) scale(0.86)`;
       cardElement.style.opacity = '0';
     });
 

--- a/styles.css
+++ b/styles.css
@@ -49,16 +49,17 @@ body {
 
 .top-bar {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
   gap: 8px;
   align-items: center;
+  row-gap: 10px;
 }
 
 .resource {
   position: relative;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 12px;
-  padding: 6px 8px 8px;
+  padding: 6px 10px 10px;
   display: grid;
   grid-template-columns: 1fr auto;
   grid-template-rows: auto auto;
@@ -70,7 +71,7 @@ body {
 
 .resource .label {
   grid-area: label;
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(248, 249, 255, 0.78);
@@ -100,6 +101,20 @@ body {
   color: #f8f9ff;
 }
 
+@media (max-width: 360px) {
+  .resource {
+    padding: 6px 8px 9px;
+  }
+
+  .resource .label {
+    font-size: 0.58rem;
+  }
+
+  .resource .value {
+    font-size: 0.78rem;
+  }
+}
+
 
 .card-area {
   flex: 1;
@@ -114,11 +129,11 @@ body {
 .card {
   position: relative;
   width: 100%;
-  background: rgba(12, 14, 24, 0.82);
+  background: transparent;
   border-radius: 24px;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: 1fr;
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(6px);
   touch-action: pan-y;
@@ -148,13 +163,13 @@ body {
 
 .card-image {
   position: relative;
-  flex: 1 1 auto;
-  min-height: 0;
+  min-height: clamp(340px, 60vh, 420px);
   background: rgba(255, 255, 255, 0.05);
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  grid-area: 1 / 1;
 }
 
 .card-image img {
@@ -165,15 +180,17 @@ body {
 }
 
 .card-body {
-  margin-top: auto;
-  padding: 18px 22px 22px;
+  position: relative;
+  grid-area: 1 / 1;
+  align-self: end;
+  padding: 32px 24px 30px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   background: none;
-  flex-shrink: 0;
   color: #f1f3ff;
-  text-shadow: 0 4px 18px rgba(0, 0, 0, 0.55);
+  text-shadow: 0 12px 32px rgba(0, 0, 0, 0.65);
+  z-index: 1;
 }
 
 .card-body h1 {
@@ -199,13 +216,16 @@ body {
   flex: 1;
   background: rgba(255, 255, 255, 0.06);
   border-radius: 12px;
-  padding: 10px 12px;
-  font-size: 0.9rem;
-  text-align: center;
+  padding: 12px;
+  font-size: 1rem;
   letter-spacing: 0.02em;
   color: rgba(248, 249, 255, 0.7);
-  text-transform: uppercase;
   transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  flex-direction: column;
 }
 
 .hint--disabled {
@@ -214,7 +234,7 @@ body {
 
 .hint::before {
   font-weight: 700;
-  margin-right: 6px;
+  font-size: 1.4rem;
 }
 
 .hint-left::before {
@@ -223,6 +243,20 @@ body {
 
 .hint-right::before {
   content: '\2192';
+}
+
+.hint::after {
+  content: attr(data-label);
+  font-size: 0.68rem;
+  text-transform: none;
+  letter-spacing: normal;
+  color: rgba(248, 249, 255, 0.72);
+  line-height: 1.2;
+}
+
+.hint[data-label='']::after,
+.hint:not([data-label])::after {
+  content: '';
 }
 
 .hint--active {


### PR DESCRIPTION
## Summary
- make the resource meters responsive so they wrap neatly on narrow screens
- restyle the card layout to remove the text backing and rely on the artwork with clearer hint icons
- enhance swipe gestures with 3D animation and accessible hint metadata

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7867065b8832e85afdaa12baa981e