### PR TITLE
Improve card stack preview and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,20 @@
         </div>
       </div>
       <div class="gesture-hints">
-        <div class="hint hint-left" id="hint-left" aria-label="Свайп влево"></div>
-        <div class="hint hint-right" id="hint-right" aria-label="Свайп вправо"></div>
+        <div class="hint hint-left" id="hint-left" aria-label="Свайп влево">
+          <span class="hint__arrow" aria-hidden="true"></span>
+          <span class="hint__text">
+            <span class="hint__direction"></span>
+            <span class="hint__label"></span>
+          </span>
+        </div>
+        <div class="hint hint-right" id="hint-right" aria-label="Свайп вправо">
+          <span class="hint__text">
+            <span class="hint__direction"></span>
+            <span class="hint__label"></span>
+          </span>
+          <span class="hint__arrow" aria-hidden="true"></span>
+        </div>
       </div>
     </main>
     <footer class="bottom-bar">

--- a/index.html
+++ b/index.html
@@ -36,13 +36,24 @@
       </div>
     </header>
     <main class="card-area">
-      <div class="card" id="card" aria-live="polite">
-        <div class="card-image">
-          <img id="card-image" alt="" src="" />
+      <div class="card-stack">
+        <div class="card card--preview" id="card-preview" aria-hidden="true">
+          <div class="card-image">
+            <img id="card-preview-image" alt="" src="" />
+          </div>
+          <div class="card-body">
+            <h1 id="card-preview-title"></h1>
+            <p id="card-preview-text"></p>
+          </div>
         </div>
-        <div class="card-body">
-          <h1 id="card-title"></h1>
-          <p id="card-text"></p>
+        <div class="card card--current" id="card" aria-live="polite">
+          <div class="card-image">
+            <img id="card-image" alt="" src="" />
+          </div>
+          <div class="card-body">
+            <h1 id="card-title"></h1>
+            <p id="card-text"></p>
+          </div>
         </div>
       </div>
       <div class="gesture-hints">

--- a/index.html
+++ b/index.html
@@ -17,22 +17,18 @@
       <div class="resource" data-key="service">
         <span class="label">Сервис</span>
         <div class="bar"><div class="fill"></div></div>
-        <span class="value">0</span>
       </div>
       <div class="resource" data-key="revenue">
         <span class="label">Доход</span>
         <div class="bar"><div class="fill"></div></div>
-        <span class="value">0</span>
       </div>
       <div class="resource" data-key="order">
         <span class="label">Порядок</span>
         <div class="bar"><div class="fill"></div></div>
-        <span class="value">0</span>
       </div>
       <div class="resource" data-key="burnout">
         <span class="label">Выгорание</span>
         <div class="bar"><div class="fill"></div></div>
-        <span class="value">0</span>
       </div>
     </header>
     <main class="card-area">
@@ -55,21 +51,13 @@
             <p id="card-text"></p>
           </div>
         </div>
-      </div>
-      <div class="gesture-hints">
-        <div class="hint hint-left" id="hint-left" aria-label="Свайп влево">
-          <span class="hint__arrow" aria-hidden="true"></span>
-          <span class="hint__text">
-            <span class="hint__direction"></span>
-            <span class="hint__label"></span>
-          </span>
+        <div class="swipe-indicator swipe-indicator--left" id="hint-left" aria-label="Свайп влево">
+          <span class="swipe-indicator__arrow" aria-hidden="true">‹</span>
+          <span class="swipe-indicator__label"></span>
         </div>
-        <div class="hint hint-right" id="hint-right" aria-label="Свайп вправо">
-          <span class="hint__text">
-            <span class="hint__direction"></span>
-            <span class="hint__label"></span>
-          </span>
-          <span class="hint__arrow" aria-hidden="true"></span>
+        <div class="swipe-indicator swipe-indicator--right" id="hint-right" aria-label="Свайп вправо">
+          <span class="swipe-indicator__arrow" aria-hidden="true">›</span>
+          <span class="swipe-indicator__label"></span>
         </div>
       </div>
     </main>

--- a/main.js
+++ b/main.js
@@ -764,32 +764,13 @@ function playCardEnterAnimation() {
   cardElement.classList.remove('card--dragging');
   clearHintActive();
 
-  cardElement.classList.remove('card--enter');
-  void cardElement.offsetWidth;
-  cardElement.classList.add('card--enter');
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    return new Promise((resolve) => {
+      window.requestAnimationFrame(() => resolve());
+    });
+  }
 
-  return new Promise((resolve) => {
-    let finished = false;
-
-    const cleanup = () => {
-      if (finished) return;
-      finished = true;
-      cardElement.classList.remove('card--enter');
-      resolve();
-    };
-
-    const handleAnimationEnd = (event) => {
-      if (event.target !== cardElement) return;
-      cardElement.removeEventListener('animationend', handleAnimationEnd);
-      cleanup();
-    };
-
-    cardElement.addEventListener('animationend', handleAnimationEnd);
-    window.setTimeout(() => {
-      cardElement.removeEventListener('animationend', handleAnimationEnd);
-      cleanup();
-    }, 700);
-  });
+  return Promise.resolve();
 }
 
 function resetGame() {

--- a/main.js
+++ b/main.js
@@ -560,9 +560,13 @@ async function handleChoice(side) {
 
         const enterAnimation = playCardEnterAnimation();
         let previewUpdated = false;
+        let fallbackTimeout = null;
         const applyUpcomingPreview = () => {
           if (previewUpdated) return;
           previewUpdated = true;
+          if (fallbackTimeout !== null) {
+            clearTimeout(fallbackTimeout);
+          }
           updatePreviewCardView(upcomingPreviewCard);
         };
 
@@ -570,12 +574,10 @@ async function handleChoice(side) {
           enterAnimation.then(applyUpcomingPreview, applyUpcomingPreview);
         }
 
-        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-          window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => {
-              applyUpcomingPreview();
-            });
-          });
+        if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
+          fallbackTimeout = window.setTimeout(() => {
+            applyUpcomingPreview();
+          }, 720);
         } else {
           applyUpcomingPreview();
         }

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ let loading = true;
 let isAnimating = false;
 const SWIPE_TRIGGER_DISTANCE = 70;
 const MAX_DRAG_DISTANCE = 180;
+let nextCardId = null;
 
 const gestureState = {
   active: false,
@@ -23,13 +24,36 @@ const elements = {
   title: document.getElementById('card-title'),
   text: document.getElementById('card-text'),
   image: document.getElementById('card-image'),
-  cardImageContainer: document.querySelector('.card-image'),
+  cardImageContainer: document.querySelector('#card .card-image'),
   card: document.getElementById('card'),
+  previewCard: document.getElementById('card-preview'),
+  previewTitle: document.getElementById('card-preview-title'),
+  previewText: document.getElementById('card-preview-text'),
+  previewImage: document.getElementById('card-preview-image'),
+  previewImageContainer: document.querySelector('#card-preview .card-image'),
+  cardStack: document.querySelector('.card-stack'),
   hintLeft: document.getElementById('hint-left'),
   hintRight: document.getElementById('hint-right'),
   status: document.getElementById('status-message'),
   reset: document.getElementById('reset-button'),
   resourceBars: Array.from(document.querySelectorAll('.resource')),
+};
+
+const cardViews = {
+  current: {
+    card: elements.card,
+    title: elements.title,
+    text: elements.text,
+    image: elements.image,
+    imageContainer: elements.cardImageContainer,
+  },
+  preview: {
+    card: elements.previewCard,
+    title: elements.previewTitle,
+    text: elements.previewText,
+    image: elements.previewImage,
+    imageContainer: elements.previewImageContainer,
+  },
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -183,6 +207,64 @@ function updateHintLabels(card) {
   setHintContent(elements.hintRight, 'Вправо', rightLabel);
 }
 
+function clearCardView(view) {
+  if (!view) return;
+  if (view.title) view.title.textContent = '';
+  if (view.text) view.text.textContent = '';
+  if (view.image) {
+    view.image.hidden = true;
+    view.image.removeAttribute('src');
+    view.image.alt = '';
+  }
+  if (view.imageContainer) {
+    view.imageContainer.style.display = 'none';
+    view.imageContainer.classList.remove('card-image--placeholder');
+  }
+}
+
+function setCardContent(view, card) {
+  if (!view) return;
+  if (!card) {
+    clearCardView(view);
+    return;
+  }
+
+  if (view.title) view.title.textContent = card.title ?? '';
+  if (view.text) view.text.textContent = card.text ?? '';
+
+  const hasImage = Boolean(card.image);
+  if (view.imageContainer) {
+    view.imageContainer.style.display = '';
+    view.imageContainer.classList.toggle('card-image--placeholder', !hasImage);
+  }
+  if (view.image) {
+    if (hasImage) {
+      view.image.hidden = false;
+      view.image.src = card.image;
+      view.image.alt = card.title ?? '';
+    } else {
+      view.image.hidden = true;
+      view.image.removeAttribute('src');
+      view.image.alt = '';
+    }
+  }
+}
+
+function updatePreviewCardView(card) {
+  if (!card) {
+    clearCardView(cardViews.preview);
+    if (cardViews.preview.card) {
+      cardViews.preview.card.classList.remove('card--visible');
+    }
+    return;
+  }
+
+  setCardContent(cardViews.preview, card);
+  if (cardViews.preview.card) {
+    cardViews.preview.card.classList.add('card--visible');
+  }
+}
+
 async function init() {
   try {
     const response = await fetch('cards.json');
@@ -270,76 +352,114 @@ function meetsConditions(card) {
   return true;
 }
 
-function drawNextCard() {
-  if (!state.deck || state.deck.length === 0) {
-    // Replenish with all cards that might still be relevant
+function ensureDeckHasCards() {
+  if (!Array.isArray(state.deck)) {
+    state.deck = [];
+  }
+  if (state.deck.length === 0) {
     state.deck = shuffle(cardList.map((card) => card.id));
   }
+}
 
+function pullNextCardId() {
+  ensureDeckHasCards();
   let attempts = state.deck.length;
   while (attempts > 0 && state.deck.length > 0) {
     const nextId = state.deck.shift();
     const card = cardMap.get(nextId);
     if (!card) {
-      attempts--;
+      attempts -= 1;
       continue;
     }
     if (meetsConditions(card)) {
-      state.currentCardId = nextId;
-      saveState();
-      renderCard();
-      return;
+      return nextId;
     }
     state.deck.push(nextId);
-    attempts--;
+    attempts -= 1;
   }
+  return null;
+}
 
+function peekNextCardId() {
+  ensureDeckHasCards();
+  const deckCopy = [...state.deck];
+  let attempts = deckCopy.length;
+  while (attempts > 0 && deckCopy.length > 0) {
+    const nextId = deckCopy.shift();
+    const card = cardMap.get(nextId);
+    if (!card) {
+      attempts -= 1;
+      continue;
+    }
+    if (meetsConditions(card)) {
+      return nextId;
+    }
+    deckCopy.push(nextId);
+    attempts -= 1;
+  }
+  return null;
+}
+
+function showNoCardsState({ skipAnimation = false } = {}) {
   state.currentCardId = null;
-  elements.title.textContent = 'Новая неделя';
-  elements.text.textContent = 'Все спокойно. Наслаждайтесь паузой или начните новую смену!';
-  elements.cardImageContainer.style.display = 'none';
-  elements.cardImageContainer.classList.remove('card-image--placeholder');
-  elements.image.hidden = true;
-  elements.image.removeAttribute('src');
-  elements.image.alt = '';
+  clearCardView(cardViews.current);
+  if (cardViews.current.title) {
+    cardViews.current.title.textContent = 'Новая неделя';
+  }
+  if (cardViews.current.text) {
+    cardViews.current.text.textContent = 'Все спокойно. Наслаждайтесь паузой или начните новую смену!';
+  }
+  updatePreviewCardView(null);
+  nextCardId = null;
   setHintContent(elements.hintLeft, 'Свайп влево', 'Пауза');
   setHintContent(elements.hintRight, 'Свайп вправо', 'Новая смена');
   elements.status.textContent = 'Подходящих карточек нет — обновите смену.';
   disableChoices(true);
   saveState();
-  playCardEnterAnimation();
+  if (!skipAnimation) {
+    playCardEnterAnimation();
+  }
 }
 
-function renderCard() {
-  if (!state.currentCardId) {
-    drawNextCard();
-    return;
+function renderCard(options = {}) {
+  const { skipAnimation = false } = options;
+
+  if (!state.currentCardId && !state.gameOver) {
+    state.currentCardId = pullNextCardId();
   }
-  const card = cardMap.get(state.currentCardId);
+
+  const card = state.currentCardId ? cardMap.get(state.currentCardId) : null;
   if (!card) {
-    drawNextCard();
+    showNoCardsState({ skipAnimation });
     return;
   }
-  disableChoices(state.gameOver);
-  elements.title.textContent = card.title;
-  elements.text.textContent = card.text;
-  const hasImage = Boolean(card.image);
-  elements.cardImageContainer.style.display = '';
-  elements.cardImageContainer.classList.toggle('card-image--placeholder', !hasImage);
-  if (hasImage) {
-    elements.image.hidden = false;
-    elements.image.src = card.image;
-    elements.image.alt = card.title;
-  } else {
-    elements.image.hidden = true;
-    elements.image.removeAttribute('src');
-    elements.image.alt = '';
-  }
+
+  setCardContent(cardViews.current, card);
   updateHintLabels(card);
-  elements.status.textContent = `День ${state.day}`;
+
+  if (state.gameOver) {
+    disableChoices(true);
+  } else {
+    disableChoices(false);
+    elements.status.textContent = `День ${state.day}`;
+  }
+
   updateResources();
+
+  if (state.gameOver) {
+    nextCardId = null;
+    updatePreviewCardView(null);
+  } else {
+    nextCardId = peekNextCardId();
+    const previewCard = nextCardId ? cardMap.get(nextCardId) : null;
+    updatePreviewCardView(previewCard);
+  }
+
   saveState();
-  playCardEnterAnimation();
+
+  if (!skipAnimation) {
+    playCardEnterAnimation();
+  }
 }
 
 function disableChoices(disabled) {
@@ -356,38 +476,67 @@ async function handleChoice(side) {
   if (loading || state.gameOver || isAnimating) return;
   const card = cardMap.get(state.currentCardId);
   if (!card) return;
-  const choice = card.choices[side];
+  const choice = card.choices?.[side];
   if (!choice) return;
 
   isAnimating = true;
   disableChoices(true);
 
-  try {
-    try {
-      await playSwipeAnimation(side);
-    } catch (error) {
-      console.warn('Swipe animation did not finish as expected', error);
-    }
+  const flyingCard = createFlyingCardClone();
+  elements.card.style.transition = '';
+  elements.card.style.transform = '';
+  elements.card.style.opacity = '';
 
+  try {
     applyEffects(choice.effects);
     applyFlags(choice.flags_set);
     applyDeckChanges(choice.adds, choice.removes);
 
     state.day += 1;
     updateResources();
-    saveState();
 
     if (checkDefeat()) {
-      renderCard();
-      return;
+      renderCard({ skipAnimation: true });
+    } else {
+      state.currentCardId = null;
+      renderCard({ skipAnimation: true });
     }
 
-    state.currentCardId = null;
-    saveState();
-    drawNextCard();
+    try {
+      await playSwipeAnimation(flyingCard, side);
+    } catch (error) {
+      console.warn('Swipe animation did not finish as expected', error);
+    }
   } finally {
+    if (flyingCard?.parentNode) {
+      flyingCard.parentNode.removeChild(flyingCard);
+    }
+    playCardEnterAnimation();
+    disableChoices(state.gameOver);
     isAnimating = false;
   }
+}
+
+function createFlyingCardClone() {
+  const baseCard = elements.card;
+  if (!baseCard || !elements.cardStack) return null;
+  const clone = baseCard.cloneNode(true);
+  clone.removeAttribute('id');
+  clone.removeAttribute('aria-live');
+  clone.setAttribute('aria-hidden', 'true');
+  clone.classList.add('card--flying');
+  clone.querySelectorAll('[id]').forEach((node) => node.removeAttribute('id'));
+  const computedStyle = window.getComputedStyle(baseCard);
+  clone.style.position = 'absolute';
+  clone.style.inset = '0';
+  clone.style.margin = '0';
+  clone.style.pointerEvents = 'none';
+  clone.style.transition = 'none';
+  clone.style.transform = baseCard.style.transform || computedStyle.transform || 'none';
+  clone.style.opacity = baseCard.style.opacity || computedStyle.opacity || '1';
+  clone.style.transformOrigin = baseCard.style.transformOrigin || computedStyle.transformOrigin || '';
+  elements.cardStack.appendChild(clone);
+  return clone;
 }
 
 function applyEffects(effects = {}) {
@@ -442,42 +591,42 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
-function playSwipeAnimation(direction) {
+function playSwipeAnimation(cardElement, direction) {
   return new Promise((resolve) => {
-    const cardElement = elements.card;
-    const computedStyle = window.getComputedStyle(cardElement);
-    const startTransform = cardElement.style.transform || computedStyle.transform || 'none';
-    const startOpacity = parseFloat(cardElement.style.opacity || computedStyle.opacity || '1');
-    const width = window.innerWidth || cardElement.offsetWidth || 1;
+    const target = cardElement || elements.card;
+    const computedStyle = window.getComputedStyle(target);
+    const startTransform = target.style.transform || computedStyle.transform || 'none';
+    const startOpacity = parseFloat(target.style.opacity || computedStyle.opacity || '1');
+    const width = window.innerWidth || target.offsetWidth || 1;
     const travelX = width * 1.35;
     const offsetX = direction === 'left' ? -travelX : travelX;
     const tiltY = direction === 'left' ? -42 : 42;
     const tiltZ = direction === 'left' ? -36 : 36;
     const tiltX = direction === 'left' ? 18 : -18;
-    const previousOrigin = cardElement.style.transformOrigin;
+    const previousOrigin = target.style.transformOrigin;
 
-    if (typeof cardElement.animate !== 'function') {
+    if (typeof target.animate !== 'function') {
       const rotateZ = direction === 'left' ? -36 : 36;
       const offsetY = -110;
       const offsetZ = -180;
-      cardElement.style.transition = 'transform 0.55s cubic-bezier(0.22, 0.71, 0.35, 1), opacity 0.5s ease';
-      cardElement.style.transformOrigin = '50% 60%';
-      cardElement.style.transform = `translate3d(${offsetX}px, ${offsetY}px, ${offsetZ}px) rotateX(${tiltX}deg) rotateY(${tiltY}deg) rotate(${rotateZ}deg) scale(0.78)`;
-      cardElement.style.opacity = '0';
+      target.style.transition = 'transform 0.55s cubic-bezier(0.22, 0.71, 0.35, 1), opacity 0.5s ease';
+      target.style.transformOrigin = '50% 60%';
+      target.style.transform = `translate3d(${offsetX}px, ${offsetY}px, ${offsetZ}px) rotateX(${tiltX}deg) rotateY(${tiltY}deg) rotate(${rotateZ}deg) scale(0.78)`;
+      target.style.opacity = '0';
       setTimeout(() => {
-        cardElement.style.transition = '';
-        cardElement.style.transform = '';
-        cardElement.style.opacity = '';
-        cardElement.style.transformOrigin = previousOrigin;
+        target.style.transition = '';
+        target.style.transform = '';
+        target.style.opacity = '';
+        target.style.transformOrigin = previousOrigin;
         resolve();
       }, 580);
       return;
     }
 
-    cardElement.style.transition = 'none';
-    cardElement.style.transformOrigin = '50% 60%';
+    target.style.transition = 'none';
+    target.style.transformOrigin = '50% 60%';
 
-    const animation = cardElement.animate(
+    const animation = target.animate(
       [
         {
           transform: startTransform === 'none' ? 'translate3d(0, 0, 0)' : startTransform,
@@ -514,10 +663,10 @@ function playSwipeAnimation(direction) {
       } catch (error) {
         // Some browsers may throw if the animation is already finished.
       }
-      cardElement.style.transition = '';
-      cardElement.style.transform = '';
-      cardElement.style.opacity = '';
-      cardElement.style.transformOrigin = previousOrigin;
+      target.style.transition = '';
+      target.style.transform = '';
+      target.style.opacity = '';
+      target.style.transformOrigin = previousOrigin;
       resolve();
     };
 
@@ -548,7 +697,8 @@ function resetGame() {
   elements.status.textContent = 'Смена сброшена. Удачи!';
   disableChoices(false);
   updateResources();
-  drawNextCard();
+  nextCardId = null;
+  renderCard();
 }
 
 function shuffle(array) {

--- a/main.js
+++ b/main.js
@@ -712,6 +712,11 @@ function playSwipeAnimation(cardElement, direction) {
       if (failSafeTimeout !== null) {
         clearTimeout(failSafeTimeout);
       }
+      try {
+        animation.cancel();
+      } catch (cancelError) {
+        // Ignore cancellation errors – animation may already be finished.
+      }
       finalize();
     };
 

--- a/main.js
+++ b/main.js
@@ -657,7 +657,17 @@ function playSwipeAnimation(cardElement, direction) {
         }
         target.style.transformOrigin = previousOrigin;
         if (isFlyingCard) {
+          target.style.visibility = 'hidden';
+          target.style.opacity = '0';
+          target.style.pointerEvents = 'none';
           target.style.display = 'none';
+          if (target.parentNode) {
+            requestAnimationFrame(() => {
+              if (target.parentNode) {
+                target.parentNode.removeChild(target);
+              }
+            });
+          }
         }
         resolve();
       }, 580);
@@ -717,6 +727,13 @@ function playSwipeAnimation(cardElement, direction) {
         target.style.opacity = '0';
         target.style.pointerEvents = 'none';
         target.style.display = 'none';
+        if (target.parentNode) {
+          requestAnimationFrame(() => {
+            if (target.parentNode) {
+              target.parentNode.removeChild(target);
+            }
+          });
+        }
       }
       resolve();
     };

--- a/main.js
+++ b/main.js
@@ -170,7 +170,8 @@ function clearHintActive() {
   elements.hintRight.classList.remove('hint--active');
 }
 
-function setHintContent(element, directionLabel, actionLabel = '') {
+function setHintContent(element, directionLabel, actionLabel = '', options = {}) {
+  const { showDirection = true, ariaDirection = directionLabel } = options;
   const directionSpan =
     element === elements.hintLeft
       ? elements.hintLeftDirection
@@ -184,19 +185,33 @@ function setHintContent(element, directionLabel, actionLabel = '') {
       ? elements.hintRightLabel
       : element.querySelector('.hint__label');
   const trimmedAction = actionLabel?.trim?.() ?? '';
-  if (directionSpan) {
-    directionSpan.textContent = trimmedAction
+  const directionText = showDirection
+    ? trimmedAction
       ? `${directionLabel}:`
-      : directionLabel;
+      : directionLabel
+    : '';
+  if (directionSpan) {
+    directionSpan.textContent = directionText;
   }
   if (labelSpan) {
     labelSpan.textContent = trimmedAction;
   }
-  const labelText = trimmedAction ? `${directionLabel}: ${trimmedAction}` : directionLabel;
-  element.setAttribute('aria-label', labelText);
+  const parts = [];
+  if (ariaDirection) {
+    parts.push(ariaDirection);
+  }
   if (trimmedAction) {
+    parts.push(trimmedAction);
+  }
+  const labelText = parts.join(': ');
+  if (labelText) {
+    element.setAttribute('aria-label', labelText);
     element.title = labelText;
+  } else if (ariaDirection) {
+    element.setAttribute('aria-label', ariaDirection);
+    element.removeAttribute('title');
   } else {
+    element.removeAttribute('aria-label');
     element.removeAttribute('title');
   }
 }
@@ -223,8 +238,14 @@ function updateHintLabels(card) {
   const leftLabel = card.choices?.left?.label ?? '';
   const rightLabel = card.choices?.right?.label ?? '';
 
-  setHintContent(elements.hintLeft, 'Влево', leftLabel);
-  setHintContent(elements.hintRight, 'Вправо', rightLabel);
+  setHintContent(elements.hintLeft, 'Свайп влево', leftLabel, {
+    showDirection: false,
+    ariaDirection: 'Свайп влево',
+  });
+  setHintContent(elements.hintRight, 'Свайп вправо', rightLabel, {
+    showDirection: false,
+    ariaDirection: 'Свайп вправо',
+  });
 }
 
 function clearCardView(view) {
@@ -641,6 +662,9 @@ function playSwipeAnimation(cardElement, direction) {
           target.style.opacity = '';
         }
         target.style.transformOrigin = previousOrigin;
+        if (isFlyingCard) {
+          target.style.display = 'none';
+        }
         resolve();
       }, 580);
       return;
@@ -694,6 +718,9 @@ function playSwipeAnimation(cardElement, direction) {
         target.style.opacity = '';
       }
       target.style.transformOrigin = previousOrigin;
+      if (isFlyingCard) {
+        target.style.display = 'none';
+      }
       resolve();
     };
 

--- a/styles.css
+++ b/styles.css
@@ -61,7 +61,7 @@ body {
   padding: 8px 10px 10px;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 6px;
 }
 
@@ -70,7 +70,8 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(248, 249, 255, 0.78);
-  text-align: left;
+  text-align: center;
+  width: 100%;
 }
 
 .resource .bar {
@@ -237,21 +238,25 @@ body {
 
 .swipe-indicator {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  flex-direction: column;
+  top: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  justify-items: center;
   align-items: center;
-  gap: 8px;
+  row-gap: 12px;
   color: rgba(248, 249, 255, 0.72);
   font-size: 0.95rem;
   text-align: center;
-  max-width: 140px;
+  max-width: 150px;
   pointer-events: none;
   z-index: 4;
   opacity: 0.85;
   transition: color 0.25s ease, opacity 0.25s ease, transform 0.25s ease;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  padding: 0 6px 14px;
+  transform: scale(1);
+  transform-origin: center;
 }
 
 .swipe-indicator--left {
@@ -265,12 +270,14 @@ body {
 .swipe-indicator__arrow {
   font-size: 2.4rem;
   line-height: 1;
+  align-self: center;
 }
 
 .swipe-indicator__label {
   font-size: 1rem;
   color: inherit;
   opacity: 0.82;
+  align-self: stretch;
 }
 
 .swipe-indicator__label:empty {
@@ -278,7 +285,7 @@ body {
 }
 
 .swipe-indicator--active {
-  transform: translateY(-50%) scale(1.02);
+  transform: scale(1.04);
   opacity: 1;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -158,14 +158,14 @@ body {
 .card--preview {
   z-index: 1;
   pointer-events: none;
-  transform: translateY(18px) scale(0.94);
+  transform: translateY(18px);
   opacity: 0;
   transition: opacity 0.28s ease, transform 0.28s ease;
 }
 
 .card--preview.card--visible {
   opacity: 0.86;
-  transform: translateY(14px) scale(0.96);
+  transform: translateY(14px);
 }
 
 .card--locked {

--- a/styles.css
+++ b/styles.css
@@ -256,6 +256,7 @@ body {
   flex-shrink: 0;
 }
 
+
 .hint {
   flex: 1;
   background: rgba(255, 255, 255, 0.06);
@@ -263,21 +264,60 @@ body {
   padding: 14px 16px;
   font-size: 1.08rem;
   letter-spacing: 0.02em;
-  color: rgba(248, 249, 255, 0.78);
+  color: rgba(248, 249, 255, 0.82);
   transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
-  flex-direction: row;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .hint--disabled {
   opacity: 0.45;
 }
 
-.hint::before {
-  content: '';
+
+.hint__text {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  line-height: 1.2;
+  flex: 1;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.hint-left .hint__text {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.hint-right .hint__text {
+  justify-content: flex-end;
+  text-align: right;
+  align-items: flex-end;
+}
+
+.hint__direction {
+  font-weight: 600;
+  color: inherit;
+}
+
+.hint__label {
+  font-size: 0.88rem;
+  color: inherit;
+  opacity: 0.78;
+}
+
+.hint--active .hint__label {
+  opacity: 0.92;
+}
+
+.hint__label:empty {
+  display: none;
+}
+
+.hint__arrow {
   display: inline-block;
   width: 0;
   height: 0;
@@ -285,28 +325,14 @@ body {
   border-color: transparent;
 }
 
-.hint-left::before {
+.hint-left .hint__arrow {
   border-width: 9px 12px 9px 0;
   border-right-color: currentColor;
 }
 
-.hint-right::before {
+.hint-right .hint__arrow {
   border-width: 9px 0 9px 12px;
   border-left-color: currentColor;
-}
-
-.hint::after {
-  content: attr(data-label);
-  font-size: 0.82rem;
-  text-transform: none;
-  letter-spacing: normal;
-  color: rgba(248, 249, 255, 0.72);
-  line-height: 1.2;
-}
-
-.hint[data-label='']::after,
-.hint:not([data-label])::after {
-  content: '';
 }
 
 .hint--active {
@@ -322,7 +348,7 @@ body {
   background: rgba(72, 202, 228, 0.35);
 }
 
-.hint--disabled::before {
+.hint--disabled .hint__arrow {
   opacity: 0.6;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -228,7 +228,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.78) 70%, rgba(255, 255, 255, 0.6) 100%);
+  background: none;
   color: #10131a;
   text-shadow: none;
   z-index: 1;
@@ -301,6 +301,10 @@ body {
 .hint__direction {
   font-weight: 600;
   color: inherit;
+}
+
+.hint__direction:empty {
+  display: none;
 }
 
 .hint__label {

--- a/styles.css
+++ b/styles.css
@@ -143,9 +143,6 @@ body {
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.3);
   backdrop-filter: blur(6px);
   touch-action: pan-y;
-  animation-duration: 0.5s;
-  animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1);
-  animation-fill-mode: both;
   will-change: transform, opacity;
   cursor: grab;
   flex: 1;
@@ -169,10 +166,6 @@ body {
 .card--preview.card--visible {
   opacity: 0.86;
   transform: translateY(14px) scale(0.96);
-}
-
-.card--enter {
-  animation-name: cardEnter;
 }
 
 .card--locked {
@@ -335,18 +328,6 @@ body {
 @media (min-width: 600px) {
   body {
     background: radial-gradient(circle at top, #2c3455, #141722 60%);
-  }
-}
-
-@keyframes cardEnter {
-  0% {
-    opacity: 0;
-    transform: translate3d(0, 24px, 0) rotateY(-12deg) scale(0.94);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translate3d(0, 0, 0) rotateY(0) scale(1);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -78,12 +78,12 @@ body {
 
 .resource .bar {
   grid-area: bar;
-  width: 100%;
+  width: 78%;
   height: 3px;
   background: rgba(255, 255, 255, 0.12);
   border-radius: 999px;
   overflow: hidden;
-  margin-top: 2px;
+  margin: 2px auto 0;
 }
 
 .resource .fill {
@@ -134,6 +134,17 @@ body {
   perspective: 1200px;
 }
 
+.card-stack {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
+.card-stack .card {
+  position: absolute;
+  inset: 0;
+}
+
 .card {
   position: relative;
   width: 100%;
@@ -154,6 +165,28 @@ body {
   min-height: 0;
   transform-style: preserve-3d;
   backface-visibility: hidden;
+}
+
+.card--current {
+  z-index: 2;
+}
+
+.card--preview {
+  z-index: 1;
+  pointer-events: none;
+  transform: translateY(18px) scale(0.94);
+  opacity: 0;
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+
+.card--preview.card--visible {
+  opacity: 0.86;
+  transform: translateY(14px) scale(0.96);
+}
+
+.card--flying {
+  z-index: 3;
+  pointer-events: none;
 }
 
 .card--enter {
@@ -194,23 +227,26 @@ body {
   padding: 32px 24px 30px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  background: none;
-  color: #f1f3ff;
-  text-shadow: 0 12px 32px rgba(0, 0, 0, 0.65);
+  gap: 12px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.78) 70%, rgba(255, 255, 255, 0.6) 100%);
+  color: #10131a;
+  text-shadow: none;
   z-index: 1;
+  align-items: center;
+  text-align: center;
 }
 
 .card-body h1 {
   margin: 0;
   font-size: 1.45rem;
+  color: #05070c;
 }
 
 .card-body p {
   margin: 0;
   line-height: 1.45;
-  color: rgba(248, 249, 255, 0.88);
-  font-size: 0.98rem;
+  color: #1a1c24;
+  font-size: 1.02rem;
 }
 
 .gesture-hints {
@@ -224,16 +260,16 @@ body {
   flex: 1;
   background: rgba(255, 255, 255, 0.06);
   border-radius: 12px;
-  padding: 12px;
-  font-size: 1rem;
+  padding: 14px 16px;
+  font-size: 1.08rem;
   letter-spacing: 0.02em;
-  color: rgba(248, 249, 255, 0.7);
+  color: rgba(248, 249, 255, 0.78);
   transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  flex-direction: column;
+  gap: 10px;
+  flex-direction: row;
 }
 
 .hint--disabled {
@@ -241,21 +277,27 @@ body {
 }
 
 .hint::before {
-  font-weight: 700;
-  font-size: 1.4rem;
+  content: '';
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
 }
 
 .hint-left::before {
-  content: '\2190';
+  border-width: 9px 12px 9px 0;
+  border-right-color: currentColor;
 }
 
 .hint-right::before {
-  content: '\2192';
+  border-width: 9px 0 9px 12px;
+  border-left-color: currentColor;
 }
 
 .hint::after {
   content: attr(data-label);
-  font-size: 0.68rem;
+  font-size: 0.82rem;
   text-transform: none;
   letter-spacing: normal;
   color: rgba(248, 249, 255, 0.72);
@@ -278,6 +320,10 @@ body {
 
 .hint-right.hint--active {
   background: rgba(72, 202, 228, 0.35);
+}
+
+.hint--disabled::before {
+  opacity: 0.6;
 }
 
 .card-image--placeholder {
@@ -306,6 +352,7 @@ body {
   min-height: 1.4em;
   font-size: 0.95rem;
   color: rgba(248, 249, 255, 0.9);
+  text-align: center;
 }
 
 @media (min-width: 600px) {

--- a/styles.css
+++ b/styles.css
@@ -58,32 +58,28 @@ body {
   position: relative;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 12px;
-  padding: 6px 8px 8px;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: auto auto;
-  grid-template-areas:
-    'label value'
-    'bar bar';
-  gap: 2px 6px;
+  padding: 8px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
 }
 
 .resource .label {
-  grid-area: label;
   font-size: 0.6rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(248, 249, 255, 0.78);
+  text-align: left;
 }
 
 .resource .bar {
-  grid-area: bar;
-  width: 78%;
+  width: 68%;
   height: 3px;
   background: rgba(255, 255, 255, 0.12);
   border-radius: 999px;
   overflow: hidden;
-  margin: 2px auto 0;
+  margin: 0 auto;
 }
 
 .resource .fill {
@@ -93,20 +89,13 @@ body {
   transition: width 0.3s ease;
 }
 
-.resource .value {
-  grid-area: value;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: #f8f9ff;
-}
-
 @media (max-width: 380px) {
   .top-bar {
     gap: 5px;
   }
 
   .resource {
-    padding: 5px 6px 7px;
+    padding: 6px 7px 8px;
     border-radius: 10px;
   }
 
@@ -114,11 +103,8 @@ body {
     font-size: 0.54rem;
   }
 
-  .resource .value {
-    font-size: 0.72rem;
-  }
-
   .resource .bar {
+    width: 72%;
     height: 2.5px;
   }
 }
@@ -249,111 +235,68 @@ body {
   font-size: 1.02rem;
 }
 
-.gesture-hints {
-  width: 100%;
+.swipe-indicator {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
-  gap: 10px;
-  flex-shrink: 0;
-}
-
-
-.hint {
-  flex: 1;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
-  padding: 14px 16px;
-  font-size: 1.08rem;
-  letter-spacing: 0.02em;
-  color: rgba(248, 249, 255, 0.82);
-  transition: background 0.25s ease, color 0.25s ease, transform 0.25s ease;
-  display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 8px;
+  color: rgba(248, 249, 255, 0.72);
+  font-size: 0.95rem;
+  text-align: center;
+  max-width: 140px;
+  pointer-events: none;
+  z-index: 4;
+  opacity: 0.85;
+  transition: color 0.25s ease, opacity 0.25s ease, transform 0.25s ease;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
 }
 
-.hint--disabled {
-  opacity: 0.45;
+.swipe-indicator--left {
+  left: 14px;
 }
 
-
-.hint__text {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-  line-height: 1.2;
-  flex: 1;
-  flex-wrap: wrap;
-  min-width: 0;
+.swipe-indicator--right {
+  right: 14px;
 }
 
-.hint-left .hint__text {
-  justify-content: flex-start;
-  text-align: left;
+.swipe-indicator__arrow {
+  font-size: 2.4rem;
+  line-height: 1;
 }
 
-.hint-right .hint__text {
-  justify-content: flex-end;
-  text-align: right;
-  align-items: flex-end;
+.swipe-indicator__label {
+  font-size: 1rem;
+  color: inherit;
+  opacity: 0.82;
 }
 
-.hint__direction {
+.swipe-indicator__label:empty {
+  display: none;
+}
+
+.swipe-indicator--active {
+  transform: translateY(-50%) scale(1.02);
+  opacity: 1;
+}
+
+.swipe-indicator--active .swipe-indicator__label {
+  opacity: 1;
   font-weight: 600;
-  color: inherit;
 }
 
-.hint__direction:empty {
-  display: none;
+.swipe-indicator--left.swipe-indicator--active {
+  color: #ff7b7b;
 }
 
-.hint__label {
-  font-size: 0.88rem;
-  color: inherit;
-  opacity: 0.78;
+.swipe-indicator--right.swipe-indicator--active {
+  color: #5ad1f0;
 }
 
-.hint--active .hint__label {
-  opacity: 0.92;
-}
-
-.hint__label:empty {
-  display: none;
-}
-
-.hint__arrow {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-color: transparent;
-}
-
-.hint-left .hint__arrow {
-  border-width: 9px 12px 9px 0;
-  border-right-color: currentColor;
-}
-
-.hint-right .hint__arrow {
-  border-width: 9px 0 9px 12px;
-  border-left-color: currentColor;
-}
-
-.hint--active {
-  transform: translateY(-2px);
-  color: #f8f9ff;
-}
-
-.hint-left.hint--active {
-  background: rgba(255, 107, 107, 0.35);
-}
-
-.hint-right.hint--active {
-  background: rgba(72, 202, 228, 0.35);
-}
-
-.hint--disabled .hint__arrow {
-  opacity: 0.6;
+.swipe-indicator--disabled {
+  opacity: 0.35;
 }
 
 .card-image--placeholder {
@@ -383,6 +326,8 @@ body {
   font-size: 0.95rem;
   color: rgba(248, 249, 255, 0.9);
   text-align: center;
+  align-self: center;
+  padding: 0 8px;
 }
 
 @media (min-width: 600px) {

--- a/styles.css
+++ b/styles.css
@@ -171,11 +171,6 @@ body {
   transform: translateY(14px) scale(0.96);
 }
 
-.card--flying {
-  z-index: 3;
-  pointer-events: none;
-}
-
 .card--enter {
   animation-name: cardEnter;
 }
@@ -240,31 +235,31 @@ body {
   position: absolute;
   top: 0;
   bottom: 0;
-  display: grid;
-  grid-template-rows: 1fr auto;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  row-gap: 12px;
+  gap: 10px;
   color: rgba(248, 249, 255, 0.72);
   font-size: 0.95rem;
   text-align: center;
-  max-width: 150px;
+  max-width: 160px;
   pointer-events: none;
   z-index: 4;
   opacity: 0.85;
   transition: color 0.25s ease, opacity 0.25s ease, transform 0.25s ease;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
-  padding: 0 6px 14px;
+  padding: 0 4px;
   transform: scale(1);
   transform-origin: center;
 }
 
 .swipe-indicator--left {
-  left: 14px;
+  left: 4px;
 }
 
 .swipe-indicator--right {
-  right: 14px;
+  right: 4px;
 }
 
 .swipe-indicator__arrow {
@@ -277,7 +272,7 @@ body {
   font-size: 1rem;
   color: inherit;
   opacity: 0.82;
-  align-self: stretch;
+  margin: 0;
 }
 
 .swipe-indicator__label:empty {


### PR DESCRIPTION
## Summary
- Add a stacked card layout with a hidden preview card so the next event is visible during swipe animations.
- Center event titles and descriptions with a light background, adjust resource bars, and restyle gesture hints with triangular arrows and larger text.
- Update swipe handling to animate a cloned card, refresh the next card preview ahead of time, and center the day status.

## Testing
- No automated tests were run (not available).


------
https://chatgpt.com/codex/tasks/task_e_68d7f2c55f54832e8efc0a0567df5750