### PR TITLE
Adjust event card heading spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -237,8 +237,8 @@ body {
 }
 
 .card-body h1 {
-  margin: 10px 0 0;
-  font-size: 1.45rem;
+  margin: 20px 0 0;
+  font-size: 1.35rem;
   color: #05070c;
 }
 


### PR DESCRIPTION
## Summary
- reduce the event card heading font size for a subtler appearance
- increase the heading's top margin to position it lower on the card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc041dc750832e9c6f2c63a6960f56