### PR TITLE
Add branching prologue story events

### DIFF
--- a/cards.json
+++ b/cards.json
@@ -1048,5 +1048,209 @@
     },
     "conditions": null,
     "chain_id": null
+  },
+  {
+    "id": "archive_whisper",
+    "title": "Шорохи из подвала.",
+    "text": "У двери архива слышны тихие шаги и шепот. Ключ тяжелеет в кармане.",
+    "image": "assets/cards/history6.jpg",
+    "tags": [
+      "story"
+    ],
+    "choices": {
+      "left": {
+        "label": "Открыть и осмотреть архив",
+        "effects": {
+          "service": 1,
+          "revenue": 0,
+          "order": -1,
+          "energy": -1
+        },
+        "adds": [
+          "cufflink_note"
+        ],
+        "removes": [
+          "archive_whisper"
+        ],
+        "flags_set": {
+          "archive_door_opened": true,
+          "archive_noise_logged": false
+        }
+      },
+      "right": {
+        "label": "Запереть дверь и усилить охрану",
+        "effects": {
+          "service": -1,
+          "revenue": 0,
+          "order": 2,
+          "energy": 0
+        },
+        "adds": [],
+        "removes": [
+          "archive_whisper",
+          "cufflink_note"
+        ],
+        "flags_set": {
+          "archive_door_opened": false,
+          "archive_noise_logged": true
+        }
+      }
+    },
+    "conditions": {
+      "requires_flags": {
+        "old_key_taken": true
+      }
+    },
+    "chain_id": null
+  },
+  {
+    "id": "skeptic_report",
+    "title": "Журнал ночной смены.",
+    "text": "Вы заполняете отчет, вспоминая странный звонок из пустой комнаты.",
+    "image": "assets/cards/history4.jpg",
+    "tags": [
+      "story"
+    ],
+    "choices": {
+      "left": {
+        "label": "Подробно описать все аномалии",
+        "effects": {
+          "service": 1,
+          "revenue": 0,
+          "order": -1,
+          "energy": -1
+        },
+        "adds": [
+          "reported_cufflink_followup"
+        ],
+        "removes": [
+          "skeptic_report"
+        ],
+        "flags_set": {
+          "skeptic_report_filed": true
+        }
+      },
+      "right": {
+        "label": "Списать на усталость и закрыть смену",
+        "effects": {
+          "service": -1,
+          "revenue": 0,
+          "order": 1,
+          "energy": 1
+        },
+        "adds": [],
+        "removes": [
+          "skeptic_report"
+        ],
+        "flags_set": {
+          "skeptic_report_filed": false
+        }
+      }
+    },
+    "conditions": {
+      "requires_flags": {
+        "old_key_returned": true
+      }
+    },
+    "chain_id": null
+  },
+  {
+    "id": "cufflink_note",
+    "title": "Записка у запонки.",
+    "text": "Под подкладкой ящика вы находите записку: строки нот и фразу \"ищи эхо на чердаке\".",
+    "image": "assets/cards/history3.jpg",
+    "tags": [
+      "story"
+    ],
+    "choices": {
+      "left": {
+        "label": "Расшифровать послание",
+        "effects": {
+          "service": 1,
+          "revenue": 0,
+          "order": -1,
+          "energy": -1
+        },
+        "adds": [],
+        "removes": [
+          "cufflink_note"
+        ],
+        "flags_set": {
+          "note_deciphered": true
+        }
+      },
+      "right": {
+        "label": "Спрятать записку в сейф",
+        "effects": {
+          "service": -1,
+          "revenue": 0,
+          "order": 1,
+          "energy": 0
+        },
+        "adds": [],
+        "removes": [
+          "cufflink_note"
+        ],
+        "flags_set": {
+          "note_deciphered": false,
+          "note_locked": true
+        }
+      }
+    },
+    "conditions": {
+      "requires_flags": {
+        "cufflink_secret": true
+      }
+    },
+    "chain_id": null
+  },
+  {
+    "id": "reported_cufflink_followup",
+    "title": "Ответ управляющего.",
+    "text": "Управляющий благодарит за бдительность и просит держать его в курсе любых совпадений с легендой о пианисте.",
+    "image": "assets/cards/history5.jpg",
+    "tags": [
+      "story"
+    ],
+    "choices": {
+      "left": {
+        "label": "Попросить разрешение продолжить расследование",
+        "effects": {
+          "service": 1,
+          "revenue": 0,
+          "order": -1,
+          "energy": -1
+        },
+        "adds": [],
+        "removes": [
+          "reported_cufflink_followup"
+        ],
+        "flags_set": {
+          "archive_investigation": true
+        }
+      },
+      "right": {
+        "label": "Закрыть вопрос и вернуться к рутине",
+        "effects": {
+          "service": -1,
+          "revenue": 0,
+          "order": 2,
+          "energy": 1
+        },
+        "adds": [],
+        "removes": [
+          "reported_cufflink_followup"
+        ],
+        "flags_set": {
+          "archive_investigation": false
+        }
+      }
+    },
+    "conditions": {
+      "requires_flags": {
+        "cufflink_reported": true
+      }
+    },
+    "chain_id": null
   }
 ]

--- a/main.js
+++ b/main.js
@@ -472,17 +472,24 @@ function getStoryCardIdForPosition(position) {
   const offsetPosition = position - 1;
   if (offsetPosition % STORY_CARD_INTERVAL !== 0) return null;
 
-  const index = Math.floor(offsetPosition / STORY_CARD_INTERVAL);
-  if (index < 0 || index >= storyCardList.length) {
-    return null;
+  let index = state.storyIndex ?? 0;
+  if (index < 0) {
+    index = 0;
   }
 
-  if (index !== state.storyIndex) {
-    return null;
+  while (index < storyCardList.length) {
+    const card = storyCardList[index];
+    if (!card || meetsConditions(card)) {
+      if (state.storyIndex !== index) {
+        state.storyIndex = index;
+      }
+      return card ? card.id : null;
+    }
+    index += 1;
+    state.storyIndex = index;
   }
 
-  const card = storyCardList[index];
-  return card ? card.id : null;
+  return null;
 }
 
 function drawCardFromDeck(deckSource) {

--- a/story_cards.json
+++ b/story_cards.json
@@ -9,68 +9,158 @@
         ],
         "choices": {
             "left": {
-                "label": "Хорошо",
+                "label": "Взять ключ и расспросить о подвале",
                 "effects": {
-                    "service": 0,
+                    "service": 1,
                     "revenue": 0,
-                    "order": 0,
-                    "energy": 0
+                    "order": -1,
+                    "energy": -1
                 },
-                "adds": [],
-                "removes": [],
-                "flags_set": {}
+                "adds": [
+                    "archive_whisper"
+                ],
+                "removes": [
+                    "skeptic_report"
+                ],
+                "flags_set": {
+                    "old_key_taken": true,
+                    "old_key_returned": false
+                }
             },
             "right": {
-                "label": "Хорошо",
+                "label": "Отказать и сосредоточиться на смене",
                 "effects": {
                     "service": 0,
                     "revenue": 0,
-                    "order": 0,
-                    "energy": 0
+                    "order": 1,
+                    "energy": 1
                 },
-                "adds": [],
-                "removes": [],
-                "flags_set": {}
+                "adds": [
+                    "skeptic_report"
+                ],
+                "removes": [
+                    "archive_whisper"
+                ],
+                "flags_set": {
+                    "old_key_taken": false,
+                    "old_key_returned": true
+                }
             }
         },
         "conditions": null,
         "chain_id": null
     },
     {
-        "id": "story_02",
-        "title": "Странная находка.",
-        "text": "Во время обхода вы замечаете под ковром в холле что-то блестящее. Это старинная запонка с инициалами \"А.Л.\". Вы убираете ее в ящик стола.",
+        "id": "story_02_alt",
+        "title": "Странная находка без ключа.",
+        "text": "Вы возвращаете запонку в бюро находок. Записи смены придется писать аккуратнее: странностей становится слишком много даже без походов в подвал.",
         "image": "assets/cards/history2.jpg",
         "tags": [
             "story"
         ],
         "choices": {
             "left": {
-                "label": "Хорошо",
+                "label": "Отложить разбор до утра",
                 "effects": {
-                    "service": 0,
+                    "service": -1,
                     "revenue": 0,
-                    "order": 0,
-                    "energy": 0
+                    "order": 1,
+                    "energy": 1
                 },
-                "adds": [],
-                "removes": [],
-                "flags_set": {}
+                "adds": [
+                    "skeptic_report"
+                ],
+                "removes": [
+                    "reported_cufflink_followup"
+                ],
+                "flags_set": {
+                    "archive_skeptic": true,
+                    "cufflink_secret": false,
+                    "cufflink_reported": false
+                }
             },
             "right": {
-                "label": "Хорошо",
+                "label": "Сообщить управляющему немедленно",
+                "effects": {
+                    "service": 1,
+                    "revenue": 0,
+                    "order": 0,
+                    "energy": -1
+                },
+                "adds": [
+                    "reported_cufflink_followup"
+                ],
+                "removes": [
+                    "skeptic_report"
+                ],
+                "flags_set": {
+                    "archive_skeptic": false,
+                    "cufflink_reported": true
+                }
+            }
+        },
+        "conditions": {
+            "requires_flags": {
+                "old_key_returned": true
+            }
+        },
+        "chain_id": null
+    },
+    {
+        "id": "story_02",
+        "title": "Странная находка.",
+        "text": "Во время обхода вы замечаете под ковром в холле что-то блестящее. Это старинная запонка с инициалами \"А.Л.\". Ключ в кармане подталкивает вернуться в архив и понять, как вещь оказалась здесь.",
+        "image": "assets/cards/history2.jpg",
+        "tags": [
+            "story"
+        ],
+        "choices": {
+            "left": {
+                "label": "Спрятать запонку как улику",
                 "effects": {
                     "service": 0,
                     "revenue": 0,
-                    "order": 0,
+                    "order": -1,
+                    "energy": -1
+                },
+                "adds": [
+                    "cufflink_note"
+                ],
+                "removes": [
+                    "reported_cufflink_followup"
+                ],
+                "flags_set": {
+                    "archive_investigation": true,
+                    "cufflink_secret": true,
+                    "cufflink_reported": false
+                }
+            },
+            "right": {
+                "label": "Передать находку охране",
+                "effects": {
+                    "service": 1,
+                    "revenue": 0,
+                    "order": 1,
                     "energy": 0
                 },
-                "adds": [],
-                "removes": [],
-                "flags_set": {}
+                "adds": [
+                    "reported_cufflink_followup"
+                ],
+                "removes": [
+                    "cufflink_note"
+                ],
+                "flags_set": {
+                    "archive_investigation": false,
+                    "cufflink_secret": false,
+                    "cufflink_reported": true
+                }
             }
         },
-        "conditions": null,
+        "conditions": {
+            "requires_flags": {
+                "old_key_taken": true
+            }
+        },
         "chain_id": null
     },
     {
@@ -83,28 +173,32 @@
         ],
         "choices": {
             "left": {
-                "label": "Хорошо",
+                "label": "Забрать книгу для изучения",
                 "effects": {
-                    "service": 0,
+                    "service": 1,
                     "revenue": 0,
-                    "order": 0,
-                    "energy": 0
+                    "order": -1,
+                    "energy": -1
                 },
                 "adds": [],
                 "removes": [],
-                "flags_set": {}
+                "flags_set": {
+                    "library_clue_saved": true
+                }
             },
             "right": {
-                "label": "Хорошо",
+                "label": "Вернуть книгу на полку",
                 "effects": {
-                    "service": 0,
+                    "service": -1,
                     "revenue": 0,
-                    "order": 0,
-                    "energy": 0
+                    "order": 1,
+                    "energy": 1
                 },
                 "adds": [],
                 "removes": [],
-                "flags_set": {}
+                "flags_set": {
+                    "library_clue_saved": false
+                }
             }
         },
         "conditions": null,


### PR DESCRIPTION
## Summary
- allow story cards with unmet conditions to be skipped so flagged branches appear at the right moments
- enrich the opening story choices with meaningful effects, flags, and deck adjustments
- add follow-up deck events that react to the player's decisions and gate themselves via flag requirements

## Testing
- node -e "const fs=require('fs');JSON.parse(fs.readFileSync('story_cards.json','utf8'));JSON.parse(fs.readFileSync('cards.json','utf8'));"

------
https://chatgpt.com/codex/tasks/task_e_68dfa65cfd0c832e93ca1d71bbcc4216